### PR TITLE
 fix Import err django.utils module; fix err install psycopg2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,6 @@ COPY --from=0 /nodebuild /app
 # Install pip requirements and collect django static files
 RUN python3 -m pip install -r requirements.txt
 RUN python3 manage.py collectstatic --noinput
+
+# pytest
+ENV PATH="/root/.local/bin"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
 ﻿astroid==2.0.4
-Django>=2.1.6
+Django==2.2.9
 python-dotenv
-djangorestframework==3.9.1
+djangorestframework==3.11.0
 isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 #psycopg2-binary==2.7.5
 # Use the following in docker to work around: https://github.com/unbit/uwsgi/issues/1569
-psycopg2==2.7.4 --no-binary psycopg2
+# psycopg2==2.7.4 --no-binary psycopg2
+psycopg2==2.8.4 
 pycodestyle==2.4.0
 pytz==2018.5
 six==1.11.0


### PR DESCRIPTION
Install/config fixes; 

fix err install psycopg2

fix Import error django.utils module 
"ImportError: cannot import name 'six' from 'django.utils' (/usr/local/lib/python3.8/site-packages/django/utils/__init__.py)"
This error occured because Django 3.x was used during the setup I've changed this now to fixed Django 2.2.x instead of > Django 2.x

